### PR TITLE
Run tests in parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,8 +45,13 @@ before_install:
 - export PATH=$HOME/.local/bin/firefox:$PATH
 -
 - # start remote ends
-- xvfb-run geckodriver --binary $HOME/.local/bin/firefox/firefox --port 4444 >/dev/null 2>/dev/null & chromedriver --port=9515 &
-- sleep 3
+- xvfb-run -a geckodriver --binary $HOME/.local/bin/firefox/firefox --port 4444 >/dev/null 2>/dev/null &
+- sleep 5
+- xvfb-run -a geckodriver --binary $HOME/.local/bin/firefox/firefox --port 4445 >/dev/null 2>/dev/null &
+- sleep 5
+- chromedriver --port=9515 &
+- chromedriver --port=9516 &
+- sleep 5
 
 
 install:

--- a/dev/doc.md
+++ b/dev/doc.md
@@ -1,0 +1,45 @@
+Info for Developers
+===================
+
+Here's some notes about the implementation of webdriver-w3c.
+
+
+About Parallelism
+-----------------
+
+If you have a large suite of tests, webdriver-w3c can speed up execution by running the tests in parallel. In fact, running the tests in parallel is no more complicated than running them sequentially. To take advantage of this you'll need to do two things:
+
+First: set the `--num-threads` option or the `TASTY_NUM_THREADS` environment variable higher than 1; this is the number of tests to be run simultaneously. (This also requires compiling your binary with `-threaded -rtsopts -with-rtsopts=-N`; see the [tasty documentation](https://github.com/feuerbach/tasty#running-tests-in-parallel) for details).
+
+Second: have more than one remote end running, and supply their URIs to your test executable. (When running on a CI server, `xvfb-run` is handy here.) You can specify these URIs on the command line directly with syntax like this:
+
+    --remote-ends 'geckodriver: URI URI chromedriver: URI URI'
+
+If your list of remote end URIs is large or dynamically generated, you can also supply it in a config file using the following option:
+
+    --remote-ends-config PATH
+
+where `PATH` is a file formatted like so:
+
+    geckodriver
+    - URI
+    - URI
+    chromedriver
+    - URI
+    - URI
+
+You can specify the remote end URIs with either `--remote-ends` or `--remote-ends-config` or both. The "blocks" of URIs per driver can be in any order and do not have to be contiguous. Note that the URIs *must* include a scheme (the `https://` part).
+
+The remote end URIs are stored in a set of mutable stacks; one for each driver. On each test run, we atomically pop a remote end URI from the stack, use it to run the tests, and then push the remote URI back onto the stack. If no remote ends are available, the test run waits until one becomes available.
+
+Note that while the tests can be _executed_ in parallel, they are still _processed_ sequentially. In particular, if you've got 100 firefox tests followed by 100 chrome tests, and provide exactly one firefox remote end and one chrome remote end, your tests will not run in parallel. The chrome remote will sit idle until all the firefox tests have finished. To get the full benefit of parallelism, I recommend having N firefox remotes and N chrome remotes and running the tests with N threads; this will not ensure that all 2N remotes are always busy, but will ensure that all N threads are being used.
+
+
+About the Tests
+---------------
+
+Tests for this library fall into two buckets: API tests, where the correct behavior is dictated by the [WebDriver spec](https://www.w3.org/TR/webdriver/); and non-API tests, which cover other behaviors of the library outside the scope of the spec. The API tests are the more important of the two.
+
+The API test suite consists of a list of WebDriver scripts in the [test/Web/Api/WebDriver/Monad/Test/Session](https://github.com/nbloomf/webdriver-w3c/tree/master/test/Web/Api/WebDriver/Monad/Test/Session) directory. These tests are divided into files by expected result; e.g. [Success](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/WebDriver/Monad/Test/Session/Success.hs) consists of the scripts that should succeed, [UnknownError](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/WebDriver/Monad/Test/Session/UnknownError.hs) consists of the scripts that should fail with "unknown error", and so on.
+
+API test scripts are run against two drivers: [geckodriver](https://github.com/mozilla/geckodriver) and a mocked remote end implementation. Later versions will also test against Chrome. The code for the mocked remote end is mainly in and under the [test/Web/Api/WebDriver/Monad/Test/Server](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/WebDriver/Monad/Test/Server.hs) namespace, with additional scaffolding under [test/Web/Api/Http/Effects/Test/Mock](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/Http/Effects/Test/Mock.hs).

--- a/dev/run-tests.sh
+++ b/dev/run-tests.sh
@@ -2,8 +2,10 @@
 
 stack build
 
-geckodriver 2>/dev/null >/dev/null &
-chromedriver &
+geckodriver --port 4444 2>/dev/null >/dev/null &
+geckodriver --port 4445 2>/dev/null >/dev/null &
+chromedriver --port=9515 &
+chromedriver --port=9516 &
 
 stack test --coverage
 

--- a/doc/Tests.md
+++ b/doc/Tests.md
@@ -1,8 +1,0 @@
-About the Tests
-===============
-
-Tests for this library fall into two buckets: API tests, where the correct behavior is dictated by the [WebDriver spec](https://www.w3.org/TR/webdriver/); and non-API tests, which cover other behaviors of the library outside the scope of the spec. The API tests are the more important of the two.
-
-The API test suite consists of a list of WebDriver scripts in the [test/Web/Api/WebDriver/Monad/Test/Session](https://github.com/nbloomf/webdriver-w3c/tree/master/test/Web/Api/WebDriver/Monad/Test/Session) directory. These tests are divided into files by expected result; e.g. [Success](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/WebDriver/Monad/Test/Session/Success.hs) consists of the scripts that should succeed, [UnknownError](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/WebDriver/Monad/Test/Session/UnknownError.hs) consists of the scripts that should fail with "unknown error", and so on.
-
-API test scripts are run against two drivers: [geckodriver](https://github.com/mozilla/geckodriver) and a mocked remote end implementation. Later versions will also test against Chrome. The code for the mocked remote end is mainly in and under the [test/Web/Api/WebDriver/Monad/Test/Server](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/WebDriver/Monad/Test/Server.hs) namespace, with additional scaffolding under [test/Web/Api/Http/Effects/Test/Mock](https://github.com/nbloomf/webdriver-w3c/blob/master/test/Web/Api/Http/Effects/Test/Mock.hs).

--- a/src/Test/Tasty/WebDriver/Config.hs
+++ b/src/Test/Tasty/WebDriver/Config.hs
@@ -1,0 +1,157 @@
+{- |
+Module      : Test.Tasty.WebDriver.Config
+Description : Helpers for parsing config files.
+Copyright   : 2018, Automattic, Inc.
+License     : GPL-3
+Maintainer  : Nathan Bloomfield (nbloomf@gmail.com)
+Stability   : experimental
+Portability : POSIX
+-}
+
+{-# LANGUAGE RecordWildCards #-}
+module Test.Tasty.WebDriver.Config (
+    DriverName(..)
+  , RemoteEndPool(..)
+  , combineRemoteEndPools
+  , addRemoteEndForDriver
+  , getRemoteEndForDriver
+  , RemoteEnd(..)
+
+  -- * Parsing
+  , parseRemoteEnd
+  , parseRemoteEndConfig
+  , parseRemoteEndOption
+  ) where
+
+import Network.URI
+import Text.Read (readMaybe)
+import Data.List (unlines, isPrefixOf, isSuffixOf, nub)
+
+import Data.Typeable
+  ( Typeable, Proxy(Proxy) )
+import qualified Data.Map.Strict as MS
+
+
+
+-- | Remote end name.
+data DriverName
+  = Geckodriver
+  | Chromedriver
+  deriving (Eq, Ord, Typeable)
+
+instance Show DriverName where
+  show Geckodriver = "geckodriver"
+  show Chromedriver = "chromedriver"
+
+
+-- | Pool of remote end connections per driver.
+data RemoteEndPool = RemoteEndPool
+  { freeRemoteEnds :: MS.Map DriverName [RemoteEnd]
+  } deriving (Eq, Show)
+
+-- | Unions two remote end pools.
+combineRemoteEndPools :: RemoteEndPool -> RemoteEndPool -> RemoteEndPool
+combineRemoteEndPools x y = RemoteEndPool
+  { freeRemoteEnds = MS.unionWith (++) (freeRemoteEnds x) (freeRemoteEnds y)
+  }
+
+-- | Push a remote end to the pool stack for a given driver.
+addRemoteEndForDriver :: DriverName -> RemoteEnd -> RemoteEndPool -> RemoteEndPool
+addRemoteEndForDriver driver remote pool = RemoteEndPool
+  { freeRemoteEnds = MS.adjust (remote:) driver $ freeRemoteEnds pool
+  }
+
+-- | Attempt to pop a remote end from the pool stack for a given driver. Returns the new pool, whether or not a remote end was popped. Returns a `Just Just` if a remote end was found, a `Just Nothing` if the driver has an empty stack of remotes, and `Nothing` if the pool is undefined for the driver.
+getRemoteEndForDriver :: DriverName -> RemoteEndPool -> (RemoteEndPool, Maybe (Maybe RemoteEnd))
+getRemoteEndForDriver driver pool =
+  case MS.lookup driver (freeRemoteEnds pool) of
+    Nothing -> (pool, Nothing)
+    Just z -> case z of
+      [] -> (pool, Just Nothing)
+      (r:rs) -> (pool { freeRemoteEnds = MS.insert driver rs $ freeRemoteEnds pool }, Just $ Just r)
+
+
+-- | Representation of a remote end connection.
+data RemoteEnd = RemoteEnd
+  { remoteEndHost :: String -- ^ Scheme, auth, and hostname
+  , remoteEndPort :: Int
+  , remoteEndPath :: String -- ^ Additional path component
+  } deriving (Eq, Show)
+
+
+-- | Parse a remote end config file. This file consists of 0 or more blocks of the form
+--
+-- > DRIVER_NAME
+-- > - REMOTE_END_URI
+-- > - REMOTE_END_URI
+--
+-- where `DRIVER_NAME` is either `geckodriver` or `chromedriver` and each `REMOTE_END_URI` is the uri of a WebDriver remote end, including scheme. Blank lines are ignored.
+parseRemoteEndConfig :: String -> Either String RemoteEndPool
+parseRemoteEndConfig str = do
+  freeEnds <- fmap (MS.fromListWith (++)) $ tokenizeRemoteEndConfig $ filter (/= "") $ lines str
+  return $ RemoteEndPool
+    { freeRemoteEnds = freeEnds
+    }
+
+
+tokenizeRemoteEndConfig :: [String] -> Either String [(DriverName, [RemoteEnd])]
+tokenizeRemoteEndConfig ls = case ls of
+  [] -> return []
+  (first:rest) -> do
+    driver <- case first of
+      "geckodriver" -> return Geckodriver
+      "chromedriver" -> return Chromedriver
+      _ -> Left $ "Unrecognized driver name '" ++ first ++ "'."
+    let (remotes, remainder) = span ("- " `isPrefixOf`) rest
+    ends <- sequence $ map (parseRemoteEnd . drop 2) remotes
+    config <- tokenizeRemoteEndConfig remainder
+    return $ (driver, nub ends) : config
+
+
+-- | Parse a remote end command line option. This option consists of 0 or more substrings of the form
+--
+-- > DRIVER_NAME: REMOTE_END_URI REMOTE_END_URI ...
+--
+-- where `DRIVER_NAME` is either `geckodriver` or `chromedriver` and each `REMOTE_END_URI` is the uri of a WebDriver remote end, including scheme.
+parseRemoteEndOption :: String -> Either String RemoteEndPool
+parseRemoteEndOption str = do
+  freeEnds <- fmap (MS.fromListWith (++)) $ tokenizeRemoteEndOption $ words str
+  return $ RemoteEndPool
+    { freeRemoteEnds = freeEnds
+    }
+
+
+tokenizeRemoteEndOption :: [String] -> Either String [(DriverName, [RemoteEnd])]
+tokenizeRemoteEndOption ws = case ws of
+  [] -> return []
+  (first:rest) -> do
+    driver <- case first of
+      "geckodriver:" -> return Geckodriver
+      "chromedriver:" -> return Chromedriver
+      _ -> Left $ "Unrecognized driver name '" ++ first ++ "'."
+    let (remotes, remainder) = span (not . isSuffixOf ":") rest
+    ends <- sequence $ map parseRemoteEnd remotes
+    option <- tokenizeRemoteEndOption remainder
+    return $ (driver, nub ends) : option
+
+
+-- | Parse a single remote end URI. Must include the scheme (http:// or https://) even though this is redundant.
+parseRemoteEnd :: String -> Either String RemoteEnd
+parseRemoteEnd str = case parseURI str of
+  Nothing -> Left $ "Could not parse remote end URI '" ++ str ++ "'."
+  Just URI{..} -> case uriAuthority of
+    Nothing -> Left $ "Error parsing authority for URI '" ++ str ++ "'."
+    Just URIAuth{..} -> case uriPort of
+      "" -> Right $ RemoteEnd
+        { remoteEndHost = uriUserInfo ++ uriRegName
+        , remoteEndPort = 4444
+        , remoteEndPath = uriPath
+        }
+      ':':ds -> case readMaybe ds of
+        Nothing -> Left $ "Error parsing port for URI '" ++ str ++ "'."
+        Just k -> Right $ RemoteEnd
+          { remoteEndHost = uriUserInfo ++ uriRegName
+          , remoteEndPort = k
+          , remoteEndPath = uriPath
+          }
+      p -> Left $ "Unexpected port '" ++ p ++ "' in URI '" ++ str ++ "'."

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,15 +1,19 @@
 module Main where
 
-import System.Environment (setEnv, lookupEnv)
+import System.Environment (setEnv, getArgs, withArgs)
+import System.Exit (exitFailure)
 import System.Directory (getCurrentDirectory)
+import Data.IORef
 
 import Test.Tasty
 import Test.Tasty.WebDriver
 
+import Test.Tasty.WebDriver.Config.Test
 import Web.Api.Http.Assert.Test
 import Web.Api.Http.Effects.Test
 import Web.Api.WebDriver.Monad.Test
 import Web.Api.WebDriver.Types.Test
+
 
 main :: IO ()
 main = do
@@ -20,25 +24,15 @@ main = do
   putStrLn "\x1b[1;34m|/\\| |___ |__) |__/ |  \\ |  \\/  |___ |  \\    |/\\| .__/ \\__,     |  |___ .__/  |  \x1b[0;39;49m"
   putStrLn "\x1b[1;34m                                                                                 \x1b[0;39;49m"
 
-  setEnv "TASTY_NUM_THREADS" "1" -- needed for live tests
+  setEnv "TASTY_NUM_THREADS" "2" -- needed for live tests
   testPagePath <- fmap (\path -> path ++ "/test/page") getCurrentDirectory
 
-  deploy <- determineDeploymentTier
-
-  defaultMain $ localOption (Deployment deploy) $ testGroup "All Tests"
-    [ Web.Api.Http.Assert.Test.tests
-    , Web.Api.WebDriver.Types.Test.tests
-    , Web.Api.Http.Effects.Test.tests testPagePath
-    , Web.Api.WebDriver.Monad.Test.tests ("file://" ++ testPagePath)
-    ]
-
-determineDeploymentTier :: IO DeploymentTier
-determineDeploymentTier = do
-  putStrLn "Determining deployment environment..."
-  deploy <- do
-    var <- lookupEnv "CI"
-    case var of
-      Just "true" -> return TEST
-      _ -> return DEV
-  putStrLn $ "Deployment environment is " ++ show deploy
-  return deploy
+  args <- getArgs
+  withArgs (["--remote-ends","geckodriver: https://localhost:4444 https://localhost:4445 chromedriver: https://localhost:9515 https://localhost:9516"] ++ args) $
+    defaultWebDriverMain $ testGroup "All Tests"
+      [ Test.Tasty.WebDriver.Config.Test.tests
+      , Web.Api.Http.Assert.Test.tests
+      , Web.Api.WebDriver.Types.Test.tests
+      , Web.Api.Http.Effects.Test.tests testPagePath
+      , Web.Api.WebDriver.Monad.Test.tests ("file://" ++ testPagePath)
+      ]

--- a/test/Test/Tasty/WebDriver/Config/Test.hs
+++ b/test/Test/Tasty/WebDriver/Config/Test.hs
@@ -1,0 +1,167 @@
+module Test.Tasty.WebDriver.Config.Test (
+    tests
+  ) where
+
+import qualified Test.Tasty as TT
+import qualified Test.Tasty.HUnit as HU
+import qualified Data.Map.Strict as MS
+
+import Test.Tasty.WebDriver.Config
+
+tests :: TT.TestTree
+tests = TT.testGroup "Test.Tasty.WebDriver.Config"
+  [ check_parseRemoteEnd
+  , check_parseRemoteEndOption
+  , check_parseRemoteEndConfig
+  ]
+
+checkParser :: (Eq a, Show a) => (String -> a) -> (String, String, a) -> TT.TestTree
+checkParser f (title, str, x) =
+  let y = f str in
+  HU.testCase title $
+    if y == x
+      then return ()
+      else do
+        HU.assertFailure $ "Error parsing '" ++ str ++ "': expected "
+          ++ show x ++ " but got " ++ show y
+
+check_parseRemoteEnd :: TT.TestTree
+check_parseRemoteEnd = TT.testGroup "parseRemoteEnd" $
+  map (checkParser parseRemoteEnd) _parseRemoteEnd_cases
+
+_parseRemoteEnd_cases :: [(String, String, Either String RemoteEnd)]
+_parseRemoteEnd_cases =
+  [ ( "'localhost'"
+    , "localhost"
+    , Left "Could not parse remote end URI 'localhost'."
+    )
+
+  , ( "'localhost:4444'"
+    , "localhost:4444"
+    , Left "Error parsing authority for URI 'localhost:4444'."
+    )
+
+  , ( "'http://localhost:4444'"
+    , "http://localhost:4444"
+    , Right $ RemoteEnd "localhost" 4444 ""
+    )
+
+  , ( "'https://localhost:4444'"
+    , "https://localhost:4444"
+    , Right $ RemoteEnd "localhost" 4444 ""
+    )
+
+  , ( "'http://localhost'"
+    , "http://localhost"
+    , Right $ RemoteEnd "localhost" 4444 ""
+    )
+
+  , ( "'https://localhost'"
+    , "https://localhost"
+    , Right $ RemoteEnd "localhost" 4444 ""
+    )
+  ]
+
+check_parseRemoteEndOption :: TT.TestTree
+check_parseRemoteEndOption = TT.testGroup "parseRemoteEndOption" $
+  map (checkParser parseRemoteEndOption) _parseRemoteEndOption_cases
+
+_parseRemoteEndOption_cases :: [(String, String, Either String RemoteEndPool)]
+_parseRemoteEndOption_cases =
+  [ ( "geckodriver+1"
+    , "geckodriver: https://localhost:4444"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Geckodriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "geckodriver+1 (repeated)"
+    , "geckodriver: https://localhost:4444 https://localhost:4444"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Geckodriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "geckodriver+2"
+    , "geckodriver: https://localhost:4444 https://localhost:4445"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Geckodriver, [RemoteEnd "localhost" 4444 "", RemoteEnd "localhost" 4445 ""])]
+    )
+
+  , ( "chromedriver+1"
+    , "chromedriver: https://localhost:4444"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Chromedriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "chromedriver+1 (repeated)"
+    , "chromedriver: https://localhost:4444 https://localhost:4444"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Chromedriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "chromedriver+2"
+    , "chromedriver: https://localhost:4444 https://localhost:4445"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Chromedriver, [RemoteEnd "localhost" 4444 "", RemoteEnd "localhost" 4445 ""])]
+    )
+
+  , ( "geckodriver+1, chromedriver+1"
+    , "geckodriver: https://localhost:4444 chromedriver: https://localhost:9515"
+    , Right $ RemoteEndPool $
+        MS.fromList
+          [ (Geckodriver, [RemoteEnd "localhost" 4444 ""])
+          , (Chromedriver, [RemoteEnd "localhost" 9515 ""])
+          ]
+    )
+  ]
+
+check_parseRemoteEndConfig :: TT.TestTree
+check_parseRemoteEndConfig = TT.testGroup "parseRemoteEndConfig" $
+  map (checkParser parseRemoteEndConfig) _parseRemoteEndConfig_cases
+
+_parseRemoteEndConfig_cases :: [(String, String, Either String RemoteEndPool)]
+_parseRemoteEndConfig_cases =
+  [ ( "geckodriver+1"
+    , "geckodriver\n- https://localhost:4444\n"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Geckodriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "geckodriver+1 (repeated)"
+    , "geckodriver\n- https://localhost:4444\n- https://localhost:4444\n"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Geckodriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "geckodriver+2"
+    , "geckodriver\n- https://localhost:4444\n- https://localhost:4445\n"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Geckodriver, [RemoteEnd "localhost" 4444 "", RemoteEnd "localhost" 4445 ""])]
+    )
+
+  , ( "chromedriver+1"
+    , "chromedriver\n- https://localhost:4444\n"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Chromedriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "chromedriver+1 (repeated)"
+    , "chromedriver\n- https://localhost:4444\n- https://localhost:4444\n"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Chromedriver, [RemoteEnd "localhost" 4444 ""])]
+    )
+
+  , ( "chromedriver+2"
+    , "chromedriver\n- https://localhost:4444\n- https://localhost:4445\n"
+    , Right $ RemoteEndPool $
+        MS.fromList [(Chromedriver, [RemoteEnd "localhost" 4444 "", RemoteEnd "localhost" 4445 ""])]
+    )
+
+  , ( "geckodriver+1, chromedriver+1"
+    , "geckodriver\n- https://localhost:4444\nchromedriver\n- https://localhost:9515\n"
+    , Right $ RemoteEndPool $
+        MS.fromList
+          [ (Geckodriver, [RemoteEnd "localhost" 4444 ""])
+          , (Chromedriver, [RemoteEnd "localhost" 9515 ""])
+          ]
+    )
+  ]

--- a/test/Web/Api/WebDriver/Monad/Test.hs
+++ b/test/Web/Api/WebDriver/Monad/Test.hs
@@ -27,14 +27,12 @@ tests path = testGroup "Web.Api.WebDriver.Monad"
 
   ,   localOption (Driver Geckodriver)
     $ localOption (ApiResponseFormat SpecFormat)
-    $ localOption (RemotePort 4444)
     $ localOption (SilentLog)
     $ localOption (AssertionLogHandle $ Path "/dev/null")
     $ testGroup "Geckodriver" (endpointTests path (return () :: IO ()))
 
   ,   localOption (Driver Chromedriver)
     $ localOption (ApiResponseFormat ChromeFormat)
-    $ localOption (RemotePort 9515)
     $ localOption (Headless True)
     $ ifTierIs TEST (localOption (BrowserPath $ Just "/usr/bin/google-chrome"))
     $ localOption (SilentLog)

--- a/test/Web/Api/WebDriver/Monad/Test/Server.hs
+++ b/test/Web/Api/WebDriver/Monad/Test/Server.hs
@@ -132,7 +132,8 @@ defaultWebDriverServer = MockServer
       [_,"session",session_id,"element",element_id,"screenshot"] ->
         get_session_id_element_id_screenshot session_id element_id
 
-      _ -> error $ "defaultWebDriverServer: get url: " ++ url
+      _ -> error $ "defaultWebDriverServer: get url: " ++ url ++
+        "' parsed as " ++ (show $ splitUrl $ stripScheme url)
 
   , __http_post = \url payload -> case splitUrl $ stripScheme url of
       {- New Session -}
@@ -243,7 +244,8 @@ defaultWebDriverServer = MockServer
       [_,"session",session_id,"alert","text"] ->
         post_session_id_alert_text session_id
 
-      _ -> error $ "defaultWebDriverServer: post url: " ++ stripScheme url
+      _ -> error $ "defaultWebDriverServer: post url: '" ++ url ++
+        "' parsed as " ++ (show $ splitUrl $ stripScheme url)
 
   , __http_delete = \url -> case splitUrl $ stripScheme url of
       {- Delete Session -}
@@ -266,11 +268,12 @@ defaultWebDriverServer = MockServer
       [_,"session",session_id,"actions"] ->
         delete_session_id_actions session_id
 
-      _ -> error $ "defaultWebDriverServer: delete url: " ++ url
+      _ -> error $ "defaultWebDriverServer: delete url: " ++ url ++
+        "' parsed as " ++ (show $ splitUrl $ stripScheme url)
   }
 
 stripScheme :: String -> String
-stripScheme str = case str of
+stripScheme str = case dropWhile (== ' ') str of
   ('h':'t':'t':'p':':':'/':'/':rest) -> rest
   ('h':'t':'t':'p':'s':':':'/':'/':rest) -> rest
   _ -> str

--- a/todo.txt
+++ b/todo.txt
@@ -1,6 +1,7 @@
 * Chromedriver compatibility: several tests are ignored for chromedriver due to spec-noncompliance. Some of these can be fixed -- notably the findElement tests -- by figuring out how to interpret chromedriver's responses.
 * Stealth commands should not log request/response details. We should test that this is the case.
-* Be able to run tests in parallel out of the box
 * /session/{session id}/element/{element id}/displayed
 * Need a ci test matrix, but have to think about how to prevent combinatorial blowup; dependencies are geckodriver+firefox+chromedriver+chrome, so matrix will get big fast. Compromise: only support one version of the drivers at a time?
 * Revisit the tasty test helpers. Does the if/unless style make sense? Do we need helpers for other options?
+* todo.txt => roadmap.md
+* Prefix option names with 'wd-' to match style of other tasty providers

--- a/webdriver-w3c.cabal
+++ b/webdriver-w3c.cabal
@@ -40,6 +40,7 @@ library
     , JuicyPixels >=3.2.9.4 && <3.3
     , lens >=4.16 && <4.17
     , lens-aeson >=1.0.2 && <1.1
+    , network-uri >= 2.6 && < 2.7
     , QuickCheck >=2.10.1 && <2.11
     , random >=1.1 && <1.2
     , scientific >=0.3.5.2 && <0.4
@@ -56,6 +57,7 @@ library
   exposed-modules:
     Test.Tasty.HttpSession
     Test.Tasty.WebDriver
+    Test.Tasty.WebDriver.Config
     Web.Api.Http
     Web.Api.Http.Assert
     Web.Api.Http.Effects
@@ -79,7 +81,8 @@ executable webdriver-w3c-intro
   default-language: Haskell2010
   main-is: Main.lhs
   hs-source-dirs: app
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       webdriver-w3c
     , base >=4.7 && <5
@@ -93,7 +96,8 @@ test-suite webdriver-w3c-test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: test
-  ghc-options: -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:
+    -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       webdriver-w3c
     , base >=4.7 && <5
@@ -101,6 +105,7 @@ test-suite webdriver-w3c-test
     , aeson >=1.2.4.0 && <1.3
     , base64-bytestring >=1.0.0.1 && <1.1
     , bytestring >=0.10.8.2 && <0.11
+    , containers >=0.5.10.2 && <0.6
     , directory >=1.3.0.2 && <1.4
     , exceptions >=0.8.3 && <0.9
     , http-client >=0.5.10 && <0.6
@@ -123,6 +128,7 @@ test-suite webdriver-w3c-test
     , wreq >=0.5.2 && <0.6
 
   other-modules:
+    Test.Tasty.WebDriver.Config.Test
     Web.Api.Http.Assert.Test
     Web.Api.Http.Effects.Test
     Web.Api.Http.Effects.Test.Mock


### PR DESCRIPTION
There are a few different ways to do this; I chose the one which (I think) is the simplest in implementation and interface, although it may not do what the user expects at first. See the added developer documentation for details.

Adds two new options, `--remote-ends` and `--remote-end-config`, for specifying remote end connections either on the command line or in a config file (or both), and keeps these in an atomically mutable stack. Each test pops a connection from the stack (if it can) and puts it back when it is done. The actual parallelization work is done by tasty.