### PR TITLE
Add retry option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,12 +46,12 @@ before_install:
 -
 - # start remote ends
 - xvfb-run -a geckodriver --binary $HOME/.local/bin/firefox/firefox --port 4444 >/dev/null 2>/dev/null &
-- sleep 5
+- sleep 2
 - xvfb-run -a geckodriver --binary $HOME/.local/bin/firefox/firefox --port 4445 >/dev/null 2>/dev/null &
-- sleep 5
+- sleep 2
 - chromedriver --port=9515 &
 - chromedriver --port=9516 &
-- sleep 5
+- sleep 2
 
 
 install:

--- a/src/Web/Api/Http/Effects.hs
+++ b/src/Web/Api/Http/Effects.hs
@@ -62,6 +62,8 @@ import Prelude hiding (try, readFile, writeFile)
 
 import Control.Concurrent
   ( threadDelay )
+import Control.Concurrent.MVar
+  ( MVar, withMVar )
 import Control.Exception
   ( Exception, try )
 import Data.Time as T
@@ -122,6 +124,9 @@ class (Monad m) => EffectConsole m where
   -- | Acts like `putStrLn`.
   mhPutStrLn :: Handle -> String -> m ()
 
+  -- | Locking `putStrLn`
+  mhBlockedPutStrLn :: MVar () -> Handle -> String -> m ()
+
 
 instance EffectConsole IO where
   mhGetEcho = hGetEcho
@@ -136,6 +141,9 @@ instance EffectConsole IO where
   mhPutChar = hPutChar
   mhPutStr = hPutStr
   mhPutStrLn = hPutStrLn
+
+  mhBlockedPutStrLn lock handle str =
+    withMVar lock (\_ -> hPutStrLn handle str)
 
 
 -- | Acts like `getChar`.

--- a/src/Web/Api/WebDriver/Monad.hs
+++ b/src/Web/Api/WebDriver/Monad.hs
@@ -142,7 +142,7 @@ data WebDriverEnv = WebDriverEnv
   , __vars :: M.Map String String -- ^ Named constants; this makes it possible to e.g. run the same WebDriver session against both a test and production environment on different hosts.
   , __response_format :: ResponseFormat -- ^ Flag for the format of HTTP responses from the remote end. E.g., chromedriver reponses are not spec-compliant.
   , __api_version :: ApiVersion -- ^ Version of the WebDriver specification.
-  } deriving Show
+  }
 
 -- | Configured for geckodriver.
 defaultWebDriverEnv :: WebDriverEnv
@@ -240,10 +240,10 @@ data WebDriverError
   = NoSession
   | ResponseError ResponseErrorCode String String (Maybe Value) Status -- ^ See <https://w3c.github.io/webdriver/webdriver-spec.html#handling-errors>
   | UnableToConnect
-  | UnhandledHttpException
+  | UnhandledHttpException N.HttpException
   | ImageDecodeError String
   | UnexpectedValue String
-  deriving (Eq, Show)
+  deriving (Show)
 
 -- | For validating responses. Throws an `UnexpectedValue` error if the two arguments are not equal according to their `Eq` instance.
 expect :: (Eq a, Show a, Effectful m) => a -> a -> WebDriver m a
@@ -268,7 +268,7 @@ promoteHttpResponseError e = case e of
 
   N.HttpExceptionRequest _ (N.ConnectionFailure _) -> Just UnableToConnect
 
-  _ -> Just UnhandledHttpException
+  _ -> Just $ UnhandledHttpException e
 
 -- | For pretty printing.
 printWebDriverError :: WebDriverError -> String
@@ -287,7 +287,7 @@ printWebDriverError e = case e of
         , "data" .= (toJSON <$> obj)
         ]
   UnableToConnect -> "Unable to connect to WebDriver server"
-  UnhandledHttpException -> "Unhandled HTTP Exception"
+  UnhandledHttpException e -> "Unhandled HTTP Exception: " ++ show e
   ImageDecodeError msg -> "Image decode: " ++ msg
   UnexpectedValue msg -> "Unexpected value: " ++ msg
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -29,10 +29,12 @@ main = do
 
   args <- getArgs
   withArgs (["--wd-remote-ends","geckodriver: https://localhost:4444 https://localhost:4445 chromedriver: https://localhost:9515 https://localhost:9516"] ++ args) $
-    defaultWebDriverMain $ testGroup "All Tests"
-      [ Test.Tasty.WebDriver.Config.Test.tests
-      , Web.Api.Http.Assert.Test.tests
-      , Web.Api.WebDriver.Types.Test.tests
-      , Web.Api.Http.Effects.Test.tests testPagePath
-      , Web.Api.WebDriver.Monad.Test.tests ("file://" ++ testPagePath)
-      ]
+    defaultWebDriverMain $
+      (localOption $ NumRetries 3) $
+        testGroup "All Tests"
+          [ Test.Tasty.WebDriver.Config.Test.tests
+          , Web.Api.Http.Assert.Test.tests
+          , Web.Api.WebDriver.Types.Test.tests
+          , Web.Api.Http.Effects.Test.tests testPagePath
+          , Web.Api.WebDriver.Monad.Test.tests ("file://" ++ testPagePath)
+          ]

--- a/test/Web/Api/Http/Effects/Test/Mock.hs
+++ b/test/Web/Api/Http/Effects/Test/Mock.hs
@@ -213,6 +213,8 @@ instance EffectConsole (MockIO st) where
 
   mhPutStrLn _ string = mPutStr (string ++ "\n")
 
+  mhBlockedPutStrLn _ _ string = mPutStr (string ++ "\n")
+
 
 instance EffectTimer (MockIO st) where
   mThreadDelay _ = return ()


### PR DESCRIPTION
Adds a new option, `--wd-num-retries`, that sets the number of times to retry a failed test.

This is implemented so that a new remote end is acquired for each attempt.

Closes #4.