### PR TITLE
Fix log file handles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ addons:
       - libgmp-dev
       - unzip
       - xvfb
-      - dbus-x11
 
 
 before_install:
@@ -67,5 +66,4 @@ before_script:
 
 
 script:
-- dbus-launch
 - stack --no-terminal test --haddock --no-haddock-deps

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,6 @@
 * Stealth commands should not log request/response details. We should test that this is the case.
 * /session/{session id}/element/{element id}/displayed
 * Need a ci test matrix, but have to think about how to prevent combinatorial blowup; dependencies are geckodriver+firefox+chromedriver+chrome, so matrix will get big fast. Compromise: only support one version of the drivers at a time?
-* todo.txt => roadmap.md
 * no_color env variable
 
 -- refactor cleanup tasks
@@ -39,4 +38,3 @@
 Notes on ignored tests
 - getAlertText on headless geckodriver
   https://bugzilla.mozilla.org/show_bug.cgi?id=1460857
-

--- a/src/Test/Tasty/WebDriver/Config.hs
+++ b/src/Test/Tasty/WebDriver/Config.hs
@@ -20,6 +20,8 @@ module Test.Tasty.WebDriver.Config (
   , parseRemoteEnd
   , parseRemoteEndConfig
   , parseRemoteEndOption
+
+  , parseOptionWithArgument
   ) where
 
 import Data.List
@@ -153,3 +155,17 @@ parseRemoteEnd str = case parseURI str of
           , remoteEndPath = uriPath
           }
       p -> Left $ "Unexpected port '" ++ p ++ "' in URI '" ++ str ++ "'."
+
+
+-- | Helper function for parsing command line options with a required argument. Assumes long-form option names starting with a hyphen. Note the return type; @Just Nothing@ indicates that the option was not present, while @Nothing@ indicates that the option was present but its required argument was not.
+parseOptionWithArgument
+  :: String -- ^ Option to parse for, including hyphen(s).
+  -> [String] -- ^ List of command line arguments.
+  -> Maybe (Maybe String)
+parseOptionWithArgument option args = case args of
+  (opt:arg:rest) -> if opt == option
+    then case arg of
+      '-':_ -> Nothing
+      _ -> Just (Just arg)
+    else parseOptionWithArgument option (arg:rest)
+  _ -> Just Nothing


### PR DESCRIPTION
Currently, trying to run tests in parallel while writing logs to a file fails, because we attempt to open the log file on each test. With this diff we open the handle once.