### PR TITLE
Bugfix: cleanupOnError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   * `readDataFile`, `writeDataFile`, `readJsonFile`, and `writeJsonFile` data helpers
 * Changed
   * Switched order of arguments for `elementSendKeys`, `getElementAttribute`, `getElementProperty`, and `getElementCssValue`. The element reference now comes last to make it easier to chain these with `>>=`.
+* Fix
+  * Bug in behavior of `cleanupOnError` was not catching all errors
 
 
 ## 0.0.1

--- a/src/Web/Api/WebDriver/Endpoints.hs
+++ b/src/Web/Api/WebDriver/Endpoints.hs
@@ -221,8 +221,11 @@ cleanupOnError
   :: (Monad m)
   => WebDriverT m a -- ^ `WebDriver` session that may throw errors
   -> WebDriverT m a
-cleanupOnError x = catchError x $ \e ->
-  deleteSession >> throwError e
+cleanupOnError x = catchAnyError x
+  (\e -> deleteSession >> throwError e)
+  (\e -> deleteSession >> throwHttpException e)
+  (\e -> deleteSession >> throwIOException e)
+  (\e -> deleteSession >> throwJsonError e)
 
 -- | Run a WebDriver computation in an isolated browser session. Ensures that the session is closed on the remote end.
 runIsolated

--- a/src/Web/Api/WebDriver/Monad.hs
+++ b/src/Web/Api/WebDriver/Monad.hs
@@ -53,6 +53,7 @@ module Web.Api.WebDriver.Monad (
   , catchJsonError
   , catchHttpException
   , catchIOException
+  , catchAnyError
   , parseJson
   , lookupKeyJson
   , constructFromJson
@@ -358,6 +359,17 @@ throwHttpException = WDT . Http.throwHttpException
 
 throwIOException :: IOException -> WebDriverT m a
 throwIOException = WDT . Http.throwIOException
+
+-- | Explicitly handle any of the error types thrown in `WebDriverT`
+catchAnyError
+  :: WebDriverT m a
+  -> (WDError -> WebDriverT m a)
+  -> (N.HttpException -> WebDriverT m a)
+  -> (IOException -> WebDriverT m a)
+  -> (Http.JsonError -> WebDriverT m a)
+  -> WebDriverT m a
+catchAnyError x hE hH hI hJ = WDT $ Http.catchAnyError (unWDT x)
+  (unWDT . hE) (unWDT . hH) (unWDT . hI) (unWDT . hJ)
 
 -- | Rethrows other error types
 catchError :: WebDriverT m a -> (WDError -> WebDriverT m a) -> WebDriverT m a

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,5 @@ packages:
 - .
 
 extra-deps:
-- script-monad-0.0.1
+- git: https://github.com/nbloomf/script-monad.git
+  commit: 6cbbb5eeeb5a91b51dbb7299828330ab4c8c90c3


### PR DESCRIPTION
An earlier refactor introduced a bug in `cleanupOnError`, causing it to not handle all error types. This patch fixes that bug.