### PR TITLE
Add breakpoints feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 * New
   * Browser preferences field on `FirefoxOptions` and `ChromeOptions`
   * `readDataFile`, `writeDataFile`, `readJsonFile`, and `writeJsonFile` data helpers
+  * `breakpoint` and `breakpointWith` for helping with debugging; controlled by `breakpointsOn`, and `breakpointsOff`
 * Changed
   * Switched order of arguments for `elementSendKeys`, `getElementAttribute`, `getElementProperty`, and `getElementCssValue`. The element reference now comes last to make it easier to chain these with `>>=`.
 * Fix
-  * Bug in behavior of `cleanupOnError` was not catching all errors
+  * Bug in behavior of `cleanupOnError` was causing it to miss some errors, which left the remote end session open
 
 
 ## 0.0.1

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,6 @@ TODO
 ====
 * Handle IO (& other) errors in cleanup helper
 * Breakpoints + breakpoint handler
-* elementSendKeys: switch order of arguments
 
 
 NEXT

--- a/app/Main.lhs
+++ b/app/Main.lhs
@@ -385,6 +385,37 @@ We can similarly use a custom inner monad to check assertions and with the tasty
 
 
 
+Debugging
+---------
+
+Running browser sessions is one thing, but writing and debugging them is another. `webdriver-w3c` has some tools for dealing with this as well. Besides the log, which gives a thorough account of what happened, we can include breakpoints in our code. When breakpoints are activated, they stop the session and give us a chance to poke around the browser before moving on.
+
+Here's a simple example.
+
+> stop_and_smell_the_ajax :: (Monad eff) => WebDriver eff ()
+> stop_and_smell_the_ajax = do
+>   breakpointsOn
+> 
+>   navigateTo "https://google.com"
+> 
+>   breakpoint "Just checking"
+> 
+>   navigateTo "https://mozilla.org"
+> 
+>   breakpoint "are we there yet"
+
+We can run this with `example5`:
+
+> example5 :: IO ()
+> example5 = do
+>   execWebDriver defaultWebDriverConfig
+>     (runIsolated defaultFirefoxCapabilities stop_and_smell_the_ajax)
+>   return ()
+
+The basic `breakpoint` command gives the option to continue, throw an error, dump the current state and environment to stdout, and turn breakpoints off. A fancier version, `breakpointWith`, takes an additional argument letting us trigger a custom action.
+
+
+
 Where to Learn More
 -------------------
 

--- a/src/Test/Tasty/WebDriver.hs
+++ b/src/Test/Tasty/WebDriver.hs
@@ -285,6 +285,7 @@ instance (Monad eff, Monad (m eff), Typeable eff, Typeable m) => TT.IsTest (WebD
               , _httpSession = Nothing
               , _userState = WDState
                 { _sessionId = Nothing
+                , _breakpoints = BreakpointsOff
                 }
               }
             , _environment = defaultWebDriverEnvironment


### PR DESCRIPTION
I'm running into a common pattern while writing and debugging tests: using
```
_ <- promptForString "blah"
```
to pause execution while I use developer tools in the browser to inspect the page state. It does the job, but points to an obvious missing feature. It'd be nice to have a better way to set "breakpoints" and/or step through a session, maybe inspecting the state along the way.

This patch adds `breakpoint`, which does exactly that.