### PR TITLE
Fix bounds on dependencies for script-monad and base

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ webdriver-w3c
 
 [![Build Status](https://travis-ci.org/nbloomf/webdriver-w3c.svg?branch=master)](https://travis-ci.org/nbloomf/webdriver-w3c)
 
-Haskell bindings for the W3C WebDriver API
+Haskell bindings for the W3C WebDriver API.
 
 
 What is it?
@@ -12,6 +12,8 @@ What is it?
 `webdriver-w3c` is a Haskell library providing bindings to the WebDriver API, enabling us to write Haskell programs that control web browsers. It is actively tested against `geckodriver` and `chromedriver`, as well as a fake remote end implementation. It is implemented as a monad transformer.
 
 Also included is an integration with the [tasty](https://hackage.haskell.org/package/tasty) test framework.
+
+Note that this library requires GHC >=8.6 due to a transitive dependency on `QuantifiedConstraints`.
 
 [WebDriver](https://www.w3.org/TR/webdriver/) is an HTTP API for interacting with a web browser remotely. It is on track to become a W3C specification and based on work done by the [Selenium](https://www.seleniumhq.org/) community.
 

--- a/webdriver-w3c.cabal
+++ b/webdriver-w3c.cabal
@@ -30,7 +30,7 @@ library
     -fwarn-incomplete-patterns
 
   build-depends:
-      base >=4.7 && <5
+      base >=4.12 && <5
 
     , aeson >=1.2.4.0
     , aeson-pretty >=0.8.5
@@ -48,7 +48,7 @@ library
     , QuickCheck >=2.10.1
     , random >=1.1
     , scientific >=0.3.5.2
-    , script-monad >=0.0.1
+    , script-monad >=0.0.3
     , SHA >=1.6.4.2
     , stm >=2.4.5.0
     , tasty >=1.0.1.1


### PR DESCRIPTION
`script-monad-0.0.3` introduced a hard dependency on GHC >= 8.6. This library was updated to reflect this, but the version bounds in the .cabal file do not reflect this.
