### PR TITLE
Fix bug in switch to frame payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ Changelog for webdriver-w3c
 Unreleased
 ----------
 
-* Bump stack resolver to lts-16.0
+* Changed
+  * Bump stack resolver to lts-16.0
+* Fixed
+  * Bug in behavior of `switchToFrame` when using `FrameContainingElement`
 
 
 

--- a/src/Web/Api/WebDriver/Endpoints.hs
+++ b/src/Web/Api/WebDriver/Endpoints.hs
@@ -520,7 +520,7 @@ switchToFrame ref = do
     !frame = case ref of
       TopLevelFrame -> Null
       FrameNumber k -> Number $ fromIntegral k
-      FrameContainingElement element_id -> String $ pack $ show element_id
+      FrameContainingElement element_id -> object [ _WEB_ELEMENT_ID .= show element_id ]
 
     !payload = encode $ object
       [ "id" .= toJSON frame ]


### PR DESCRIPTION
Our payload for the switch to frame endpoint is not spec compliant when specifying the frame by element ID; we currently pass the element as

```
{ 'id': $foo }
```

rather than the correct

```
{ 'id': { 'element-6066-11e4-a52e-4f735466cecf': $foo } }
```

See the webdriver spec for more detail: https://w3c.github.io/webdriver/#switch-to-frame