### PR TITLE
Add `runIsolated_` and change behavior of `runIsolated`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ Unreleased
 
 * Changed
   * Bump stack resolver to lts-16.0
+  * The old behavior of `runIsolated` has been renamed to `runIsolated_`, and `runIsolated` now returns the result of its argument. The naming is meant to mimic the `sequence_`/`sequence` pattern.
 * Fixed
   * Bug in behavior of `switchToFrame` when using `FrameContainingElement`
-* Changed
-  * The old behavior of `runIsolated` has been renamed to `runIsolated_`, and `runIsolated` now returns the result of its argument. The naming is meant to mimic the `sequence_`/`sequence` pattern.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Unreleased
   * Bump stack resolver to lts-16.0
 * Fixed
   * Bug in behavior of `switchToFrame` when using `FrameContainingElement`
+* Changed
+  * The old behavior of `runIsolated` has been renamed to `runIsolated_`, and `runIsolated` now returns the result of its argument. The naming is meant to mimic the `sequence_`/`sequence` pattern.
 
 
 

--- a/app/Main.lhs
+++ b/app/Main.lhs
@@ -85,13 +85,13 @@ followed by (enter). You should see a Firefox window open, go fullscreen, and se
 > example1 :: IO ()
 > example1 = do
 >   execWebDriverT defaultWebDriverConfig
->     (runIsolated defaultFirefoxCapabilities do_a_barrel_roll)
+>     (runIsolated_ defaultFirefoxCapabilities do_a_barrel_roll)
 >   return ()
 
 Let's break down what just happened.
 
 1. `do_a_barrel_roll` is a *WebDriver session*, expressed in the `WebDriver` DSL. It's a high-level description for a sequence of browser actions: in this case, "make the window full screen", "navigate to google.com", and so on.
-2. `runIsolated` takes a WebDriver session and runs it in a fresh browser instance. The parameters of this instance are specified in `defaultFirefoxCapabilities`.
+2. `runIsolated_` takes a WebDriver session and runs it in a fresh browser instance. The parameters of this instance are specified in `defaultFirefoxCapabilities`.
 3. `execWebDriver` takes a WebDriver session and carries out the steps, using some options specified in `defaultWebDriverConfig`.
 
 You probably also noticed a bunch of noise got printed to your terminal starting with something like this:
@@ -205,14 +205,14 @@ This is `example2`:
 > example2 :: IO ()
 > example2 = do
 >   (_, result) <- debugWebDriverT defaultWebDriverConfig
->     (runIsolated defaultFirefoxCapabilities what_page_is_this)
+>     (runIsolated_ defaultFirefoxCapabilities what_page_is_this)
 >   printSummary result
 >   return ()
 
 Here's what happened:
 
 1. `what_page_is_this` is a WebDriver session, just like `do_a_barrel_roll`, this time including an assertion: that the title of some web page is "Welcome to Lycos!".
-2. `runIsolated` runs `what_page_is_this` in a fresh browser instance.
+2. `runIsolated_` runs `what_page_is_this` in a fresh browser instance.
 3. `debugWebDriver` works much like `execWebDriver`, except that it collects the results of any assertion statements and summarizes them (this is `result`).
 4. `printSummary` takes the assertion results and prints them out all pretty like.
 
@@ -373,7 +373,7 @@ Running our custom WebDriver monad is then straightforward.
 > example4 t = do
 >   execReaderT (env t) $
 >     execWebDriverTT defaultWebDriverConfig
->       (runIsolated defaultFirefoxCapabilities custom_environment)
+>       (runIsolated_ defaultFirefoxCapabilities custom_environment)
 >   return ()
 
 Try it out with
@@ -411,7 +411,7 @@ We can run this with `example5`:
 > example5 :: IO ()
 > example5 = do
 >   execWebDriverT defaultWebDriverConfig
->     (runIsolated defaultFirefoxCapabilities stop_and_smell_the_ajax)
+>     (runIsolated_ defaultFirefoxCapabilities stop_and_smell_the_ajax)
 >   return ()
 
 The basic `breakpoint` command gives the option to continue, throw an error, dump the current state and environment to stdout, and turn breakpoints off. A fancier version, `breakpointWith`, takes an additional argument letting us trigger a custom action.

--- a/doc/Tutorial.md
+++ b/doc/Tutorial.md
@@ -109,7 +109,7 @@ fullscreen, and search Google for "do a barrel roll".
 example1 :: IO ()
 example1 = do
   execWebDriver defaultWebDriverConfig
-    (runIsolated defaultFirefoxCapabilities do_a_barrel_roll)
+    (runIsolated_ defaultFirefoxCapabilities do_a_barrel_roll)
   return ()
 ```
 
@@ -119,7 +119,7 @@ Let's break down what just happened.
     `WebDriver` DSL. It's a high-level description for a sequence of
     browser actions: in this case, "make the window full screen",
     "navigate to google.com", and so on.
-2.  `runIsolated` takes a WebDriver session and runs it in a fresh
+2.  `runIsolated_` takes a WebDriver session and runs it in a fresh
     browser instance. The parameters of this instance are specified in
     `defaultFirefoxCapabilities`.
 3.  `execWebDriver` takes a WebDriver session and carries out the steps,
@@ -274,7 +274,7 @@ This is `example2`:
 example2 :: IO ()
 example2 = do
   (_, result) <- debugWebDriver defaultWebDriverConfig
-    (runIsolated defaultFirefoxCapabilities what_page_is_this)
+    (runIsolated_ defaultFirefoxCapabilities what_page_is_this)
   printSummary result
   return ()
 ```
@@ -284,7 +284,7 @@ Here's what happened:
 1.  `what_page_is_this` is a WebDriver session, just like
     `do_a_barrel_roll`, this time including an assertion: that the title
     of some web page is "Welcome to Lycos!".
-2.  `runIsolated` runs `what_page_is_this` in a fresh browser instance.
+2.  `runIsolated_` runs `what_page_is_this` in a fresh browser instance.
 3.  `debugWebDriver` works much like `execWebDriver`, except that it
     collects the results of any assertion statements and summarizes them
     (this is `result`).
@@ -496,7 +496,7 @@ example4 :: Tier -> IO ()
 example4 t = do
   execReaderT (env t) $
     execWebDriverT defaultWebDriverConfig liftReaderT
-      (runIsolated defaultFirefoxCapabilities custom_environment)
+      (runIsolated_ defaultFirefoxCapabilities custom_environment)
   return ()
 ```
 
@@ -545,7 +545,7 @@ We can run this with `example5`:
 example5 :: IO ()
 example5 = do
   execWebDriver defaultWebDriverConfig
-    (runIsolated defaultFirefoxCapabilities stop_and_smell_the_ajax)
+    (runIsolated_ defaultFirefoxCapabilities stop_and_smell_the_ajax)
   return ()
 ```
 

--- a/src/Test/Tasty/WebDriver.hs
+++ b/src/Test/Tasty/WebDriver.hs
@@ -317,7 +317,7 @@ instance
             }
 
         (result, summary) <- wdToIO $ debugWebDriverTT config $
-            title >> attemptLabel attemptNumber >> runIsolated caps wdTestSession
+            title >> attemptLabel attemptNumber >> runIsolated_ caps wdTestSession
 
         atomically $ releaseRemoteEnd remotesRef driver remote
 

--- a/src/Web/Api/WebDriver/Endpoints.hs
+++ b/src/Web/Api/WebDriver/Endpoints.hs
@@ -18,6 +18,7 @@ The most recent version of the spec is available at <https://w3c.github.io/webdr
 {-# LANGUAGE OverloadedStrings, BangPatterns #-}
 module Web.Api.WebDriver.Endpoints (
     runIsolated
+  , runIsolated_
 
   -- * Sessions
   -- ** New Session
@@ -236,13 +237,22 @@ runIsolated
   :: (Monad eff, Monad (t eff), MonadTrans t)
   => Capabilities
   -> WebDriverTT t eff a
-  -> WebDriverTT t eff ()
+  -> WebDriverTT t eff a
 runIsolated caps theSession = cleanupOnError $ do
   session_id <- newSession caps
   modifyState $ setSessionId (Just session_id)
-  theSession
+  a <- theSession
   deleteSession
   modifyState $ setSessionId Nothing
+  return a
+
+runIsolated_
+  :: (Monad eff, Monad (t eff), MonadTrans t)
+  => Capabilities
+  -> WebDriverTT t eff a
+  -> WebDriverTT t eff ()
+runIsolated_ caps theSession =
+  runIsolated caps theSession >> return ()
 
 
 


### PR DESCRIPTION
The old `runIsolated` function threw away the result value, but sometimes it's nice to have access to this. Here we rename this behavior to `runIsolated_` and have `runIsolated` return the value. This is a minor breaking change, however the fix is simply to call `runIsolated_` instead of `runIsolated` in your code.

I chose this breaking change over a less disruptive one to mimic the underscore pattern that is standard among monadic functions in the ecosystem, such as `sequence_`/`sequence` or `mapM_`/`mapM`.