### PR TITLE
Update remote end versions in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 - travis_retry curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz | tar xz -C ~/.local/bin
 -
 - # install chromedriver
-- wget -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/2.38/chromedriver_linux64.zip
+- wget -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_linux64.zip
 - unzip /tmp/chromedriver.zip chromedriver -d ~/.local/bin
 -
 - # install firefox

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 - travis_retry curl -L https://get.haskellstack.org/stable/linux-x86_64.tar.gz | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 -
 - # install geckodriver
-- travis_retry curl -L https://github.com/mozilla/geckodriver/releases/download/v0.23.0/geckodriver-v0.23.0-linux64.tar.gz | tar xz -C ~/.local/bin
+- travis_retry curl -L https://github.com/mozilla/geckodriver/releases/download/v0.29.0/geckodriver-v0.29.0-linux64.tar.gz | tar xz -C ~/.local/bin
 -
 - # install chromedriver
 - wget -O /tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/89.0.4389.23/chromedriver_linux64.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Unreleased
 * Changed
   * Bump stack resolver to lts-16.0
   * The old behavior of `runIsolated` has been renamed to `runIsolated_`, and `runIsolated` now returns the result of its argument. The naming is meant to mimic the `sequence_`/`sequence` pattern.
+  * `chromeOptions` renamed to `goog:chromeOptions` in `ToJSON` `FromJSON` instances for `Capability` for compatibility with chromedriver versions >=75; see https://chromedriver.storage.googleapis.com/75.0.3770.8/notes.txt. Fixes issue #21.
 * Fixed
   * Bug in behavior of `switchToFrame` when using `FrameContainingElement`
 

--- a/src/Web/Api/WebDriver/Types.hs
+++ b/src/Web/Api/WebDriver/Types.hs
@@ -336,7 +336,7 @@ instance FromJSON Capabilities where
     <*> v .:? "setWindowRect"
     <*> v .:? "timeouts"
     <*> v .:? "unhandledPromptBehavior"
-    <*> v .:? "chromeOptions"
+    <*> v .:? "goog:chromeOptions"
     <*> v .:? "moz:firefoxOptions"
   parseJSON invalid = typeMismatch "Capabilities" invalid
 
@@ -351,7 +351,7 @@ instance ToJSON Capabilities where
     , "setWindowRect" .=? (toJSON <$> _setWindowRect)
     , "timeouts" .=? (toJSON <$> _timeouts)
     , "unhandledPromptBehavior" .=? (toJSON <$> _unhandledPromptBehavior)
-    , "chromeOptions" .=? (toJSON <$> _chromeOptions)
+    , "goog:chromeOptions" .=? (toJSON <$> _chromeOptions)
     , "moz:firefoxOptions" .=? (toJSON <$> _firefoxOptions)
     ]
 

--- a/test/Web/Api/WebDriver/Monad/Test.hs
+++ b/test/Web/Api/WebDriver/Monad/Test.hs
@@ -33,7 +33,7 @@ tests path = testGroup "Web.Api.WebDriver.Monad"
     $ testGroup "Geckodriver" $ endpointTests testCase path
 
   ,   localOption (Driver Chromedriver)
-    $ localOption (ApiResponseFormat ChromeFormat)
+    $ localOption (ApiResponseFormat SpecFormat)
     $ localOption (Headless True)
     $ ifTierIs TEST (localOption (BrowserPath $ Just "/usr/bin/google-chrome"))
     $ localOption (SilentLog)


### PR DESCRIPTION
Most notably, chromedriver versions >=75 now prefix the `chromeOptions` key as `goog:chromeOptions` when opening new sessions to comply with the w3c spec ([release notes](https://chromedriver.storage.googleapis.com/75.0.3770.8/notes.txt)). Fixes #21.