### PR TITLE
Fix goBack test for chromedriver

### DIFF
--- a/test/Web/Api/WebDriver/Monad/Test/Server/State.hs
+++ b/test/Web/Api/WebDriver/Monad/Test/Server/State.hs
@@ -96,13 +96,12 @@ _load_page
   -> Maybe WebDriverServerState
 _load_page path st = do
   let file = fileOnly path
-  p <- if file == "success.html"
-    then return _success_page
-    else if file == "invalidElementState.html"
-      then return _invalidElementState_page
-      else if file == "about:blank"
-        then return pageAboutBlank
-        else requestPage path (_internets st)
+  p <- case file of
+    "success.html"             -> return _success_page
+    "example.com"              -> return _success_page
+    "invalidElementState.html" -> return _invalidElementState_page
+    "about:blank"              -> return pageAboutBlank
+    _                          -> requestPage path (_internets st)
   return $ st
     { _current_page = p
     , _history = (_current_page st) : _history st

--- a/test/Web/Api/WebDriver/Monad/Test/Session/Success.hs
+++ b/test/Web/Api/WebDriver/Monad/Test/Session/Success.hs
@@ -178,6 +178,8 @@ _test_goBack_success
 _test_goBack_success =
   let
     session = do
+      () <- navigateTo "https://example.com"
+        -- chromedriver gets cranky if we try to navigate back when there is no history :)
       () <- goBack
       assertSuccess "yay"
       return ()


### PR DESCRIPTION
Sometime between chromedriver versions 89.0.4389.23 and 100.0.4896.60, the behavior of the /session/$sessionId/back endpoint changed such that calling this endpoint in a browser context with no history causes chromedriver to crash. This patch adds a 'navigate to example.com' step to the goBack test to avoid the crash.