### PR TITLE
Set tasty wd-private-mode option default to False

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Unreleased
   * `chromeOptions` renamed to `goog:chromeOptions` in `ToJSON` `FromJSON` instances for `Capability` for compatibility with chromedriver versions >=75; see https://chromedriver.storage.googleapis.com/75.0.3770.8/notes.txt. Fixes issue #21.
 * Fixed
   * Bug in behavior of `switchToFrame` when using `FrameContainingElement`
+  * Default value of wd-private-mode tasty flag changed to `False`
 
 
 

--- a/src/Test/Tasty/WebDriver.hs
+++ b/src/Test/Tasty/WebDriver.hs
@@ -490,7 +490,7 @@ newtype PrivateMode
   deriving Typeable
 
 instance TO.IsOption PrivateMode where
-  defaultValue = PrivateMode True
+  defaultValue = PrivateMode False
   parseValue = fmap PrivateMode . TO.safeReadBool
   optionName = return _OPT_PRIVATE_MODE
   optionHelp = return "run in private mode: (false), true"


### PR DESCRIPTION
The default value of the `wd-private-mode` flag should be False. I'm not sure why, but it wasn't. That's a bug.