### PR TITLE
Support Aeson >= 2.0.0

### DIFF
--- a/src/Web/Api/WebDriver/Endpoints.hs
+++ b/src/Web/Api/WebDriver/Endpoints.hs
@@ -180,6 +180,7 @@ import Data.Text.Encoding
   ( encodeUtf8 )
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Base64 as B64
+import Data.String (IsString)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Network.URI.Encode as E
@@ -191,15 +192,15 @@ import Web.Api.WebDriver.Monad
 
 
 -- | Spec-defined "web element identifier" string constant. See <https://w3c.github.io/webdriver/webdriver-spec.html#elements>.
-_WEB_ELEMENT_ID :: Text
+_WEB_ELEMENT_ID :: (IsString t) => t
 _WEB_ELEMENT_ID = "element-6066-11e4-a52e-4f735466cecf"
 
 -- | Spec-defined "web window identifier" string constant. See <https://w3c.github.io/webdriver/webdriver-spec.html#command-contexts>.
-_WEB_WINDOW_ID :: Text
+_WEB_WINDOW_ID :: (IsString t) => t
 _WEB_WINDOW_ID =  "window-fcc6-11e5-b4f8-330a88ab9d7f"
 
 -- | Spec-defined "web frame identifier" string constant. See <https://w3c.github.io/webdriver/webdriver-spec.html#command-contexts>.
-_WEB_FRAME_ID :: Text
+_WEB_FRAME_ID :: (IsString t) => t
 _WEB_FRAME_ID = "frame-075b-4da1-b6ba-e579c2d3230a"
 
 

--- a/src/Web/Api/WebDriver/Types.hs
+++ b/src/Web/Api/WebDriver/Types.hs
@@ -12,7 +12,7 @@ The WebDriver protocol involves passing several different kinds of JSON objects.
 Note that while the WebDriver spec defines some JSON objects, in general a given WebDriver server can accept additional properties on any given object. Our types here will be limited to the "spec" object signatures, but our API will need to be user extensible.
 -}
 
-{-# LANGUAGE OverloadedStrings, RecordWildCards, BangPatterns #-}
+{-# LANGUAGE OverloadedStrings, RecordWildCards, BangPatterns, CPP #-}
 module Web.Api.WebDriver.Types (
   -- * Stringy Types
     SessionId
@@ -118,6 +118,11 @@ import Test.QuickCheck.Gen
 import Text.Read
   ( readMaybe )
 
+-- aeson 2.0.0.0 introduced KeyMap over HashMap
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.Key (fromText)
+#endif
+
 import Web.Api.WebDriver.Uri
 
 
@@ -136,10 +141,20 @@ object_ :: [Maybe Pair] -> Value
 object_ = object . filter (\(_, v) -> v /= Null) . catMaybes
 
 (.==) :: (ToJSON v, KeyValue kv) => Text -> v -> Maybe kv
-(.==) key value = Just (key .= value)
+(.==) key value =
+#if MIN_VERSION_aeson(2,0,0)
+  Just ((fromText key) .= value) --    val = lookup (fromText key) obj
+#else
+  Just (key .= value)
+#endif
 
 (.=?) :: (ToJSON v, KeyValue kv) => Text -> Maybe v -> Maybe kv
-(.=?) key = fmap (key .=)
+(.=?) key =
+#if MIN_VERSION_aeson(2,0,0)
+  fmap ((fromText key) .=)
+#else
+  fmap (key .=)
+#endif
 
 
 

--- a/src/Web/Api/WebDriver/Types.hs
+++ b/src/Web/Api/WebDriver/Types.hs
@@ -92,6 +92,10 @@ module Web.Api.WebDriver.Types (
   , ResponseErrorCode(..)
   ) where
 
+#if MIN_VERSION_base(4,9,0)
+import Prelude hiding (fail)
+#endif
+
 import Control.Monad.IO.Class
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.Base64 as B64
@@ -117,6 +121,11 @@ import Test.QuickCheck.Gen
   ( listOf, oneof, elements )
 import Text.Read
   ( readMaybe )
+
+-- Transitional MonadFail implementation
+#if MIN_VERSION_base(4,9,0)
+import Control.Monad.Fail
+#endif
 
 -- aeson 2.0.0.0 introduced KeyMap over HashMap
 #if MIN_VERSION_aeson(2,0,0)


### PR DESCRIPTION
Aeson 2 made a minor backward incompatible change, introducing a custom `Key` type for use with JSON data. This patch supports this change in a way that does not change (in a backward compatibility breaking way) the types of the API.