### PR TITLE
Added an initial default.nix that can build webdriver-w3c.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{ nixpkgs ? (import (builtins.fetchTarball {
+    name = "nixos-master";
+    url = https://github.com/NixOS/nixpkgs/archive/c4a9eafb61919a075059075340bda90394d35f93.tar.gz;
+    # Hash obtained using `nix-prefetch-url --unpack <url>`
+    sha256 = "1rc0m28wywzkniz9y871fdv7dhml4f4xdgcfmbv5s5bicb0pyma5";
+  }) {}), compiler ? "ghc8107" }:
+let
+  pkgs = nixpkgs.pkgs;
+  haskLib = pkgs.haskell.lib;
+  overriddenHaskellPackages = pkgs.haskell.packages.${compiler}.override {
+    overrides = self: super: {
+      script-monad = haskLib.dontCheck (super.callHackage "script-monad" "0.0.4" {});
+      webdriver-w3c = haskLib.dontCheck (super.callCabal2nix "webdriver-w3c" ./. {});
+    };
+  };
+  webdriver-w3c = overriddenHaskellPackages.webdriver-w3c;
+in
+  webdriver-w3c 


### PR DESCRIPTION
This is a very early cut of a file that'll get webdriver-w3c to be built via nix, so it can be built with just `nix-build .` in the root of the project and it'll do all the heavy lifting.

The only particularly unusual thing is the `dontCheck` wrapper around `script-monad` and `webdriver-w3c` which just prevents their test suites from being built and run. For `script-monad` this is because it attempts to make a network call which nix prevents so that builds can't break the reproducibility of the build. Similarly the `webdriver-w3c` test suite relies on instances of geckodriver and chromedriver. Both of those projects could do with a build flag that disable any tests which rely on those and then eventually get these packages flagged as good in nixpkgs with that flag set.